### PR TITLE
implement mouse over

### DIFF
--- a/splash_main_3d.js
+++ b/splash_main_3d.js
@@ -1829,7 +1829,7 @@ class FrontEnd {
 
                     let selectedMeshName = THAT.Model.elevations["north"].activeAreaData.mesh_name;
 
-                    if (!meshes[THAT.previousHoveredEntryIndex].name.includes(selectedMeshName)) {
+                    if (!meshes[THAT.previousHoveredEntryIndex].name.includes("glasses_" + selectedMeshName)) {
                         meshes[THAT.previousHoveredEntryIndex].material = meshe_materials[THAT.previousHoveredEntryIndex]
                     }
                     

--- a/splash_main_3d.js
+++ b/splash_main_3d.js
@@ -1820,6 +1820,24 @@ class FrontEnd {
 				}
 			}
 
+            let clearPreviousHoveredSelection = function () {
+                if (THAT.previousHoveredEntryIndex < 0) {
+                    return;
+                }
+
+                if (THAT.Model.elevations["north"].activeAreaData) {
+
+                    let selectedMeshName = THAT.Model.elevations["north"].activeAreaData.mesh_name;
+
+                    if (!meshes[THAT.previousHoveredEntryIndex].name.includes(selectedMeshName)) {
+                        meshes[THAT.previousHoveredEntryIndex].material = meshe_materials[THAT.previousHoveredEntryIndex]
+                    }
+                    
+                } else {
+                    meshes[THAT.previousHoveredEntryIndex].material = meshe_materials[THAT.previousHoveredEntryIndex]
+                }
+            }
+
             let onMouseMove = function (evt) {
                 if (THAT.searchFlag) return;
 
@@ -1844,8 +1862,8 @@ class FrontEnd {
                     meshAreaHovered = true;
 
                     if (pickInfo.hit && (pickInfo.pickedMesh.name.substr(0, 7) == "glasses" ||
-                                        pickInfo.pickedMesh.name.substr(-5) == "coridor" ||
-                                        pickInfo.pickedMesh.name.substr(-13) == "balkony_glass")) {
+                        pickInfo.pickedMesh.name.substr(-5) == "coridor" ||
+                        pickInfo.pickedMesh.name.substr(-13) == "balkony_glass")) {
                         isMesh = true
                         mesh_str = p_mesh.name.split("_")
 
@@ -1864,25 +1882,9 @@ class FrontEnd {
                 }
 
                 if (!meshAreaHovered) {
-                    if (!THAT.previousHoveredEntry) {
-                        return;
-                    }
-
-                    if (THAT.Model.elevations["north"].activeAreaData) {
-
-                        let selectedMeshName = THAT.Model.elevations["north"].activeAreaData.mesh_name;
-
-                        if (!meshes[THAT.previousHoveredEntryIndex].name.includes(selectedMeshName)) {
-                            meshes[THAT.previousHoveredEntryIndex].material = meshe_materials[THAT.previousHoveredEntryIndex]
-                        }
-
-                    } else {
-                        meshes[THAT.previousHoveredEntryIndex].material = meshe_materials[THAT.previousHoveredEntryIndex]
-                    }
-
+                    clearPreviousHoveredSelection()
                     THAT.previousHoveredEntryIndex = -1
                     THAT.previousHoveredEntry = null
-
                     return;
                 }
 
@@ -1896,7 +1898,6 @@ class FrontEnd {
                 }
 
                 if (THAT.Model.elevations["north"].activeAreaData) {
-
                     let selectedMeshName = THAT.Model.elevations["north"].activeAreaData.mesh_name;
 
                     if (selected_balkony == selectedMeshName) {
@@ -1904,23 +1905,20 @@ class FrontEnd {
                     }
                 }
 
-
-                let selected_item = 0
-                let highlight = selected_balkony + "_walls"
                 let highLightWindow = "glasses_" + selected_balkony
                 let selectedEntryIndex = -1;
 
-
                 for (let index = 0; index < meshes.length; index++) {
 
-                    //---------------------------------------------------------------------manual property click----------------------------------------
                     if (highLightWindow == meshes[index].name) {
-                        var myMaterial = new BABYLON.StandardMaterial("myMaterial", scene)
-                        myMaterial.emissiveColor = new BABYLON.Color3(0.00, 0.18, 0.00)
-                        myMaterial.environmentIntensity = 0.1
-                        myMaterial.alpha = 0.8
 
                         if (THAT.tileData[selected_balkony]) {
+                            var myMaterial = new BABYLON.StandardMaterial("myMaterial", scene)
+                            myMaterial.emissiveColor = new BABYLON.Color3(0.00, 0.18, 0.00)
+                            myMaterial.environmentIntensity = 0.1
+                            myMaterial.alpha = 0.8
+
+                            THAT.tileData[selected_balkony].RENDERATOR.dataEntry.orientation = "north"
                             if (THAT.tileData[selected_balkony].RENDERATOR.dataEntry.availability == "false") {
                                 myMaterial.diffuseColor = new BABYLON.Color3(1, 51 / 255, 15 / 255)
                                 myMaterial.specularColor = new BABYLON.Color3(1, 51 / 255, 45 / 255)
@@ -1933,45 +1931,21 @@ class FrontEnd {
                                 myMaterial.diffuseColor = new BABYLON.Color3(51 / 255, 51 / 255, 1)
                                 myMaterial.specularColor = new BABYLON.Color3(51 / 255, 51 / 255, 1)
                                 myMaterial.emissiveColor = new BABYLON.Color3(51 / 255, 51 / 255, 1)
-                            }
+							}
+							
+							myMaterial.ambientColor = new BABYLON.Color3(0.23, 0.98, 0.53)
+							meshes[index].visibility = 1
+							meshes[index].material = myMaterial
+							selectedEntryIndex = index;
 
+							break;
                         }
 
-                        myMaterial.ambientColor = new BABYLON.Color3(0.23, 0.98, 0.53)
-                        meshes[index].visibility = 1
-                        meshes[index].material = myMaterial
-                        selectedEntryIndex = index;
-
-                        break;
+                        
                     }
                 }
 
-
-                if (THAT.tileData[selected_balkony] == undefined) return
-
-                if (THAT.previousHoveredEntryIndex > 0) {
-
-                    if (THAT.Model.elevations["north"].activeAreaData) {
-
-                        let selectedMeshName = THAT.Model.elevations["north"].activeAreaData.mesh_name;
-
-                        if (!meshes[THAT.previousHoveredEntryIndex].name.includes(selectedMeshName)) {
-                            meshes[THAT.previousHoveredEntryIndex].material = meshe_materials[THAT.previousHoveredEntryIndex]
-                        }
-
-                    } else {
-
-                        meshes[THAT.previousHoveredEntryIndex].material = meshe_materials[THAT.previousHoveredEntryIndex]
-                    }
-                }
-
-                if (THAT.tileData[selected_balkony].RENDERATOR.dataEntry.availability == true) {
-                    meshes[selected_item].material.diffuseColor = new BABYLON.Color3(0, 0, 91 / 255)
-                } else {
-                    meshes[selected_item].material.diffuseColor = new BABYLON.Color3(250 / 255, 50 / 255, 50 / 255)
-                }
-
-                THAT.tileData[selected_balkony].RENDERATOR.dataEntry.orientation = "north"
+                clearPreviousHoveredSelection();
 
                 THAT.previousHoveredEntryIndex = selectedEntryIndex;
                 THAT.previousHoveredEntry = selected_balkony;

--- a/splash_main_3d.js
+++ b/splash_main_3d.js
@@ -108,6 +108,8 @@ class FrontEnd {
 		this.sunlight = 1
 		this.isFirst = true
 		this.cameraRadius = 150
+		this.previousHoveredEntry = ""
+		this.previousHoveredEntryIndex = -1
 	}
 
 	updatePersonalizationSplash(onSplashBackgroundReady) {
@@ -1818,15 +1820,180 @@ class FrontEnd {
 				}
 			}
 
+            let onMouseMove = function (evt) {
+                if (THAT.searchFlag) return;
+
+                let canvas_panel = THAT.Model.elevations["north"].elevationCanvas
+                let p_mesh = []
+                let tolerence = 1
+                let isMesh = false
+                let pickInfo = []
+                let selected_balkony = ""
+                let meshAreaHovered = false;
+
+                for (let i = 0; i < 5; i++) {
+                    pickInfo = scene.pick(scene.pointerX + tolerence * Math.cos((0.3 * Math.PI * i) / 5),
+                        scene.pointerY + tolerence * Math.sin((0.3 * Math.PI * i) / 5),
+                        function (mesh) {
+                            return mesh !== []
+                        })
+                    p_mesh = pickInfo.pickedMesh
+                    if (p_mesh == undefined) {
+                        continue
+                    }
+
+                    meshAreaHovered = true;
+
+                    if (pickInfo.hit && (pickInfo.pickedMesh.name.substr(0, 7) == "glasses" ||
+                                        pickInfo.pickedMesh.name.substr(-5) == "coridor" ||
+                                        pickInfo.pickedMesh.name.substr(-13) == "balkony_glass")) {
+                        isMesh = true
+                        mesh_str = p_mesh.name.split("_")
+
+                        if (pickInfo.pickedMesh.name.substr(0, 7) == "glasses") {
+                            selected_balkony = mesh_str[1]
+                        } else if (pickInfo.pickedMesh.name.substr(-5) == "walls") {
+                            selected_balkony = p_mesh.name.substr(0, p_mesh.name.length - 6)
+                        } else if (pickInfo.pickedMesh.name.substr(-13) == "balkony_glass") {
+                            selected_balkony = p_mesh.name.substr(0, p_mesh.name.length - 14)
+                        } else {
+                        }
+
+                        break
+                    } else {
+                    }
+                }
+
+                if (!meshAreaHovered) {
+                    if (!THAT.previousHoveredEntry) {
+                        return;
+                    }
+
+                    if (THAT.Model.elevations["north"].activeAreaData) {
+
+                        let selectedMeshName = THAT.Model.elevations["north"].activeAreaData.mesh_name;
+
+                        if (!meshes[THAT.previousHoveredEntryIndex].name.includes(selectedMeshName)) {
+                            meshes[THAT.previousHoveredEntryIndex].material = meshe_materials[THAT.previousHoveredEntryIndex]
+                        }
+
+                    } else {
+                        meshes[THAT.previousHoveredEntryIndex].material = meshe_materials[THAT.previousHoveredEntryIndex]
+                    }
+
+                    THAT.previousHoveredEntryIndex = -1
+                    THAT.previousHoveredEntry = null
+
+                    return;
+                }
+
+                if (THAT.previousHoveredEntry == selected_balkony) {
+                    return
+                }
+
+                if (isMesh) {
+                } else {
+                    return
+                }
+
+                if (THAT.Model.elevations["north"].activeAreaData) {
+
+                    let selectedMeshName = THAT.Model.elevations["north"].activeAreaData.mesh_name;
+
+                    if (selected_balkony == selectedMeshName) {
+                        return
+                    }
+                }
+
+
+                let selected_item = 0
+                let highlight = selected_balkony + "_walls"
+                let highLightWindow = "glasses_" + selected_balkony
+                let selectedEntryIndex = -1;
+
+
+                for (let index = 0; index < meshes.length; index++) {
+
+                    //---------------------------------------------------------------------manual property click----------------------------------------
+                    if (highLightWindow == meshes[index].name) {
+                        var myMaterial = new BABYLON.StandardMaterial("myMaterial", scene)
+                        myMaterial.emissiveColor = new BABYLON.Color3(0.00, 0.18, 0.00)
+                        myMaterial.environmentIntensity = 0.1
+                        myMaterial.alpha = 0.8
+
+                        if (THAT.tileData[selected_balkony]) {
+                            if (THAT.tileData[selected_balkony].RENDERATOR.dataEntry.availability == "false") {
+                                myMaterial.diffuseColor = new BABYLON.Color3(1, 51 / 255, 15 / 255)
+                                myMaterial.specularColor = new BABYLON.Color3(1, 51 / 255, 45 / 255)
+                                myMaterial.emissiveColor = new BABYLON.Color3(1, 51 / 255, 45 / 255)
+                            } else if (THAT.tileData[selected_balkony].RENDERATOR.dataEntry.areaType == "commercial") {
+                                myMaterial.diffuseColor = new BABYLON.Color3(1, 91 / 255, 55 / 255)
+                                myMaterial.specularColor = new BABYLON.Color3(1, 91 / 255, 95 / 255)
+                                myMaterial.emissiveColor = new BABYLON.Color3(1, 91 / 255, 95 / 255)
+                            } else if (THAT.tileData[selected_balkony].RENDERATOR.dataEntry.areaType == "common") {
+                                myMaterial.diffuseColor = new BABYLON.Color3(51 / 255, 51 / 255, 1)
+                                myMaterial.specularColor = new BABYLON.Color3(51 / 255, 51 / 255, 1)
+                                myMaterial.emissiveColor = new BABYLON.Color3(51 / 255, 51 / 255, 1)
+                            }
+
+                        }
+
+                        myMaterial.ambientColor = new BABYLON.Color3(0.23, 0.98, 0.53)
+                        meshes[index].visibility = 1
+                        meshes[index].material = myMaterial
+                        selectedEntryIndex = index;
+
+                        break;
+                    }
+                }
+
+
+                if (THAT.tileData[selected_balkony] == undefined) return
+
+                if (THAT.previousHoveredEntryIndex > 0) {
+
+                    if (THAT.Model.elevations["north"].activeAreaData) {
+
+                        let selectedMeshName = THAT.Model.elevations["north"].activeAreaData.mesh_name;
+
+                        if (!meshes[THAT.previousHoveredEntryIndex].name.includes(selectedMeshName)) {
+                            meshes[THAT.previousHoveredEntryIndex].material = meshe_materials[THAT.previousHoveredEntryIndex]
+                        }
+
+                    } else {
+
+                        meshes[THAT.previousHoveredEntryIndex].material = meshe_materials[THAT.previousHoveredEntryIndex]
+                    }
+                }
+
+                if (THAT.tileData[selected_balkony].RENDERATOR.dataEntry.availability == true) {
+                    meshes[selected_item].material.diffuseColor = new BABYLON.Color3(0, 0, 91 / 255)
+                } else {
+                    meshes[selected_item].material.diffuseColor = new BABYLON.Color3(250 / 255, 50 / 255, 50 / 255)
+                }
+
+                THAT.tileData[selected_balkony].RENDERATOR.dataEntry.orientation = "north"
+
+                THAT.previousHoveredEntryIndex = selectedEntryIndex;
+                THAT.previousHoveredEntry = selected_balkony;
+
+                if (startingPoint) {
+                    startingPoint = null
+                    return
+                }
+            }
+
 			let eventCanvas = engine.getRenderingCanvas()
 			eventCanvas.addEventListener("pointerdown", onPointerDown, false)
 			eventCanvas.addEventListener("pointermove", onPointerMove, false)
 			eventCanvas.addEventListener("pointerup", onPointerUp, false)
+			eventCanvas.addEventListener("mousemove", onMouseMove, false)
 
 			scene.onDispose = function() {
 				eventCanvas.removeEventListener("pointerdown", onPointerDown)
 				eventCanvas.removeEventListener("pointermove", onPointerMove)
 				eventCanvas.removeEventListener("pointerup", onPointerUp)
+                eventCanvas.removeEventListener("mousemove", onMouseMove)
 			}
 			return scene
 		}

--- a/splash_main_3d.js
+++ b/splash_main_3d.js
@@ -1823,7 +1823,6 @@ class FrontEnd {
             let onMouseMove = function (evt) {
                 if (THAT.searchFlag) return;
 
-                let canvas_panel = THAT.Model.elevations["north"].elevationCanvas
                 let p_mesh = []
                 let tolerence = 1
                 let isMesh = false


### PR DESCRIPTION
Implement mouse over functionality with these scenarios below:

Scenario: No filter is applied
Given: There is no filter applied 
When: Users move mouse over the apartment
Then: Building will be highlighted: green if available, red if unavailable 

Scenario: No filter is applied and a apartment is selected
Given: There is no filter applied and an apartment is selected
When: Users move mouse over the other apartment
Then: The building will be highlighted: green if available, red if unavailable. The color of the selected apartment remains unchanged.

Scenario: Filters are applied
Given: Filters are applied
When: Users move mouse over the apartment
Then: Keep current selected filter colors

Scenario: Filters are applied and an apartment is selected
Given: There is no filter applied and an apartment is selected
When: Users move mouse over the other apartment
Then: The color of the selected apartment remains unchanged. No highlight when mouse over the other apartment (This can be improved later)

